### PR TITLE
refactor(moverox-traits-derive): use `darling` instead of `deluxe`

### DIFF
--- a/crates/moverox-traits-derive/Cargo.toml
+++ b/crates/moverox-traits-derive/Cargo.toml
@@ -30,9 +30,8 @@ proc-macro2 = { version = "1", public = true }
 syn         = { version = "2", public = true, features = ["clone-impls"] }
 
 convert_case = "0.8"
-deluxe       = "0.5"
+darling      = "0.20"
 quote        = "1"
-rustversion  = "1"
 
 [dev-dependencies]
 moverox-traits = { path = "../moverox-traits", features = ["derive"] }

--- a/crates/moverox-traits-derive/src/attributes.rs
+++ b/crates/moverox-traits-derive/src/attributes.rs
@@ -1,13 +1,19 @@
+#![expect(
+    clippy::option_if_let_else,
+    reason = "Generated code by `#[darling(default)]`"
+)]
+
+use darling::FromDeriveInput;
 use syn::{Ident, Path, parse_quote};
 
-#[derive(deluxe::ExtractAttributes)]
-#[deluxe(attributes(move_))]
+#[derive(FromDeriveInput)]
+#[darling(attributes(move_))]
 pub(crate) struct MoveAttributes {
-    #[deluxe(rename = crate)]
+    #[darling(rename = "crate")]
     pub(crate) thecrate: Option<Path>,
     pub(crate) address: Option<String>,
     pub(crate) module: Option<Ident>,
-    #[deluxe(default = false)]
+    #[darling(default)]
     pub(crate) nameless: bool,
 }
 

--- a/crates/moverox-traits-derive/src/datatype.rs
+++ b/crates/moverox-traits-derive/src/datatype.rs
@@ -1,3 +1,4 @@
+use darling::FromDeriveInput as _;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::punctuated::Punctuated;
@@ -14,9 +15,9 @@ pub(crate) struct Datatype {
 
 impl Datatype {
     pub(crate) fn parse(item: TokenStream) -> syn::Result<Self> {
-        let mut ast: DeriveInput = syn::parse2(item)?;
+        let ast: DeriveInput = syn::parse2(item)?;
         ensure_nonempty_struct(&ast)?;
-        let attrs: MoveAttributes = deluxe::extract_attributes(&mut ast)?;
+        let attrs = MoveAttributes::from_derive_input(&ast)?;
         validate_datatype_generics(&ast.generics)?;
         let type_tag = TypeTagStruct::new(&ast, &attrs);
         Ok(Self {
@@ -210,14 +211,14 @@ fn validate_datatype_generics(generics: &Generics) -> syn::Result<()> {
                 }) {
                     continue;
                 }
-                return Err(deluxe::Error::new_spanned(
+                return Err(syn::Error::new_spanned(
                     type_param,
                     "Move datatypes can at most have the `moverox_traits::MoveType` bound on its \
                         type parameters",
                 ));
             }
             _ => {
-                return Err(deluxe::Error::new_spanned(
+                return Err(syn::Error::new_spanned(
                     param,
                     "Only Type generics are supported",
                 ));

--- a/crates/moverox-traits-derive/src/lib.rs
+++ b/crates/moverox-traits-derive/src/lib.rs
@@ -58,7 +58,7 @@ pub fn move_datatype_derive_macro(item: proc_macro::TokenStream) -> proc_macro::
         .into()
 }
 
-fn impl_move_datatype(item: TokenStream) -> deluxe::Result<TokenStream> {
+fn impl_move_datatype(item: TokenStream) -> syn::Result<TokenStream> {
     let datatype = Datatype::parse(item)?;
 
     let type_tag_decl = datatype.type_tag.struct_declaration();


### PR DESCRIPTION
The former has less dependencies + it's shared by `serde_with_macros`
