### PR TITLE
fix(codegen): tolerate sibling `#[ext(...)]` sub-attributes

### DIFF
--- a/crates/moverox-codegen/src/attributes.rs
+++ b/crates/moverox-codegen/src/attributes.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use move_syn::Attributes;
 use quote::quote;
-use unsynn::{IParse as _, Ident, ToTokens as _, TokenStream};
+use unsynn::{CommaDelimitedVec, IParse as _, Ident, ToTokens as _, TokenStream};
 
 use crate::Result;
 
@@ -56,6 +56,23 @@ mod grammar {
             /// For now, only defaults like `{T} = OTW` are supported
             default: kw::Otw,
         }
+
+        /// A single comma-separated entry inside an `#[ext(...)]` group.
+        ///
+        /// `#[ext(...)]` is a shared namespace: other tooling attaches its own sub-attributes
+        /// (e.g. `versioned(...)`, `dynamic_field(...)`) alongside `moverox(...)`. We parse the
+        /// whole group and keep only the `moverox(...)` entries, ignoring the rest.
+        pub(crate) enum ExtEntry {
+            Moverox(Annotation),
+            Other(OtherEntry),
+        }
+
+        /// Any non-`moverox` `#[ext(...)]` entry. Consumes everything up to the next comma,
+        /// so it accepts every shape other tooling might use — `versioned(EFoo)`,
+        /// `dynamic_field(name = ID, value = ID)`, `foo = b"bar"`, a bare `dev_inspect`, …
+        pub(crate) struct OtherEntry {
+            tokens: Vec<Cons<Except<Comma>, TokenTree>>,
+        }
     }
 
     impl Annotation {
@@ -101,8 +118,22 @@ pub(super) fn extract(attrs: &[Attributes]) -> Result<(TokenStream, HashSet<Iden
 }
 
 pub(super) fn as_moverox(attr: &Attributes) -> impl Iterator<Item = self::grammar::Annotation> {
+    // An `#[ext(...)]` group may carry sibling sub-attributes from other tooling
+    // (e.g. `#[ext(moverox(type_(T = OTW)), versioned(EFoo))]`). Parse the whole
+    // comma-delimited group and keep only the `moverox(...)` entries, so a sibling
+    // attribute never causes the `moverox(...)` annotation to be dropped.
     attr.external_attributes()
-        .filter_map(|ext| ext.to_token_iter().parse_all().ok())
+        .filter_map(|ext| {
+            ext.to_token_iter()
+                .parse_all::<CommaDelimitedVec<self::grammar::ExtEntry>>()
+                .ok()
+        })
+        .flat_map(|entries| {
+            entries.into_iter().filter_map(|entry| match entry.value {
+                self::grammar::ExtEntry::Moverox(annotation) => Some(annotation),
+                self::grammar::ExtEntry::Other(_) => None,
+            })
+        })
 }
 
 fn process_doc(attr: &Attributes) -> TokenStream {

--- a/crates/moverox-codegen/src/tests.rs
+++ b/crates/moverox-codegen/src/tests.rs
@@ -281,6 +281,40 @@ fn enum_with_otw_type() {
 }
 
 #[test]
+fn enum_with_otw_type_and_sibling_ext_attrs() {
+    // `#[ext(...)]` is a shared namespace: other tooling attaches sibling sub-attributes
+    // alongside `moverox(...)` — both the `name(...)` shape (`versioned(...)`) and the
+    // `key = value` shape (`foo = b"bar"`). The `moverox(type_(T = OTW))` default must
+    // still be honored regardless of what siblings are present.
+    let move_enum = indoc! {r#"
+        #[ext(moverox(type_(T = OTW)), versioned(future_error = EFutureCollateral), foo = b"bar")]
+        public enum Collateral<phantom T> {
+            Some(Balance<T>),
+            None,
+        }
+    "#};
+    insta::assert_snapshot!(from_enum(move_enum), @r#"
+    #[derive(
+        Clone,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        ::moverox::traits::MoveDatatype,
+        ::moverox::serde::Deserialize,
+        ::moverox::serde::Serialize,
+    )]
+    #[move_(crate = ::moverox::traits)]
+    #[serde(crate = "::moverox::serde")]
+    #[allow(non_snake_case)]
+    pub enum Collateral<T = ::moverox::Otw> {
+        Some(Balance<T>),
+        None,
+    }
+    "#);
+}
+
+#[test]
 fn enum_with_duplicate_type_annotations() {
     let move_enum = indoc! {"
         #[ext(moverox(type_(T = OTW, T = OTW)))]


### PR DESCRIPTION
`#[ext(...)]` is a shared namespace — downstream tooling attaches its own sub-attributes (e.g. `versioned(...)`, `dynamic_field(...)`) next to `moverox(...)`.

`as_moverox` used `parse_all::<Annotation>()` on the whole `#[ext(...)]` group, which fails on unconsumed trailing tokens the moment a sibling attribute is present — silently dropping the `moverox(...)` annotation and erasing declared type-parameter defaults like `type_(T = OTW)`. Downstream, that turned `pub enum Collateral<T = ::moverox::Otw>` back into `Collateral<T>`, breaking callers that relied on the default.

This parses the group as a comma-delimited list and keeps only the `moverox(...)` entries, ignoring the rest. Adds a regression test (`enum_with_otw_type_and_sibling_ext_attr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)