### PR TITLE
feat(codegen): add `ModuleGen::to_parts` for placeable module bodies

### DIFF
--- a/crates/moverox-codegen/src/lib.rs
+++ b/crates/moverox-codegen/src/lib.rs
@@ -32,14 +32,40 @@ use self::move_struct::StructGen as _;
 type BoxError = Box<dyn std::error::Error + 'static>;
 type Result<T = (), E = BoxError> = std::result::Result<T, E>;
 
+/// A Move module's oxidized datatypes, split into placeable pieces.
+///
+/// Lets the body be merged into an existing `mod` of the same name (e.g. one also holding PTB
+/// bindings) rather than forced into its own `pub mod`. Produced by [`ModuleGen::to_parts`];
+/// [`ModuleGen::to_rust`] wraps it back up.
+pub struct ModuleParts {
+    /// The module identifier.
+    pub ident: Ident,
+    /// The module's doc attributes.
+    pub docs: TokenStream,
+    /// What goes *inside* `pub mod <ident>`: the `address`/`u256`/`vector` type aliases followed
+    /// by the generated `struct`/`enum` datatypes.
+    pub body: TokenStream,
+}
+
 #[sealed::sealed]
 pub trait ModuleGen {
+    /// Generate the module's datatypes as a standalone `pub mod <ident> { .. }`.
     fn to_rust(
         &self,
         thecrate: &TokenStream,
         package: Option<&LiteralString>,
         address_map: &HashMap<Ident, TokenStream>,
     ) -> Result<TokenStream>;
+
+    /// Generate the module's datatypes as placeable [`ModuleParts`], so a caller can weave the
+    /// body into a `mod` of its own construction (e.g. alongside other generated items for the
+    /// same Move module).
+    fn to_parts(
+        &self,
+        thecrate: &TokenStream,
+        package: Option<&LiteralString>,
+        address_map: &HashMap<Ident, TokenStream>,
+    ) -> Result<ModuleParts>;
 }
 
 #[sealed::sealed]
@@ -50,6 +76,22 @@ impl ModuleGen for Module {
         package: Option<&LiteralString>,
         address_map: &HashMap<Ident, TokenStream>,
     ) -> Result<TokenStream> {
+        let ModuleParts { ident, docs, body } = self.to_parts(thecrate, package, address_map)?;
+        Ok(quote! {
+            #docs
+            #[allow(rustdoc::all, clippy::too_long_first_doc_paragraph)]
+            pub mod #ident {
+                #body
+            }
+        })
+    }
+
+    fn to_parts(
+        &self,
+        thecrate: &TokenStream,
+        package: Option<&LiteralString>,
+        address_map: &HashMap<Ident, TokenStream>,
+    ) -> Result<ModuleParts> {
         let (docs, other) = crate::attributes::extract(&self.attrs)
             .map_err(|err| format!("Parsing `moverox` attributes: {err}"))?;
 
@@ -57,11 +99,11 @@ impl ModuleGen for Module {
             return Err("Move modules cannot have custom `moverox` attributes".into());
         }
 
-        let ident = &self.ident;
+        let ident = self.ident.clone();
         let item_ctx = ItemContext {
             thecrate,
             package,
-            module: Some(ident),
+            module: Some(&ident),
             address_map,
         };
         let datatypes: TokenStream = self
@@ -69,20 +111,18 @@ impl ModuleGen for Module {
             .map(|item| item.to_rust(item_ctx))
             .collect::<Result<_>>()?;
 
-        Ok(quote! {
-            #docs
-            #[allow(rustdoc::all, clippy::too_long_first_doc_paragraph)]
-            pub mod #ident {
-                #[allow(non_camel_case_types, unused)]
-                type address = #thecrate::types::Address;
-                #[allow(non_camel_case_types, unused)]
-                type u256 = #thecrate::types::U256;
-                #[allow(non_camel_case_types, unused)]
-                type vector<T> = ::std::vec::Vec<T>;
+        let body = quote! {
+            #[allow(non_camel_case_types, unused)]
+            type address = #thecrate::types::Address;
+            #[allow(non_camel_case_types, unused)]
+            type u256 = #thecrate::types::U256;
+            #[allow(non_camel_case_types, unused)]
+            type vector<T> = ::std::vec::Vec<T>;
 
-                #datatypes
-            }
-        })
+            #datatypes
+        };
+
+        Ok(ModuleParts { ident, docs, body })
     }
 }
 

--- a/crates/moverox-codegen/tests/snapshots/public_api__public_api.snap
+++ b/crates/moverox-codegen/tests/snapshots/public_api__public_api.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/moverox-codegen/tests/public-api.rs
+assertion_line: 20
 expression: public_api
 ---
 pub mod moverox_codegen
@@ -8,11 +9,17 @@ pub moverox_codegen::ItemContext::address_map: &'a std::collections::hash::map::
 pub moverox_codegen::ItemContext::module: core::option::Option<&'a proc_macro2::Ident>
 pub moverox_codegen::ItemContext::package: core::option::Option<&'a unsynn::literal::LiteralString>
 pub moverox_codegen::ItemContext::thecrate: &'a proc_macro2::TokenStream
+pub struct moverox_codegen::ModuleParts
+pub moverox_codegen::ModuleParts::body: proc_macro2::TokenStream
+pub moverox_codegen::ModuleParts::docs: proc_macro2::TokenStream
+pub moverox_codegen::ModuleParts::ident: proc_macro2::Ident
 pub trait moverox_codegen::ItemGen: moverox_codegen::__seal_item_gen::Sealed
 pub fn moverox_codegen::ItemGen::to_rust(&self, ctx: moverox_codegen::ItemContext<'_>) -> core::result::Result<proc_macro2::TokenStream, alloc::boxed::Box<(dyn core::error::Error + 'static)>>
 impl moverox_codegen::ItemGen for move_syn::Item
 pub fn move_syn::Item::to_rust(&self, ctx: moverox_codegen::ItemContext<'_>) -> core::result::Result<proc_macro2::TokenStream, alloc::boxed::Box<(dyn core::error::Error + 'static)>>
 pub trait moverox_codegen::ModuleGen: moverox_codegen::__seal_module_gen::Sealed
+pub fn moverox_codegen::ModuleGen::to_parts(&self, thecrate: &proc_macro2::TokenStream, package: core::option::Option<&unsynn::literal::LiteralString>, address_map: &std::collections::hash::map::HashMap<proc_macro2::Ident, proc_macro2::TokenStream>) -> core::result::Result<moverox_codegen::ModuleParts, alloc::boxed::Box<(dyn core::error::Error + 'static)>>
 pub fn moverox_codegen::ModuleGen::to_rust(&self, thecrate: &proc_macro2::TokenStream, package: core::option::Option<&unsynn::literal::LiteralString>, address_map: &std::collections::hash::map::HashMap<proc_macro2::Ident, proc_macro2::TokenStream>) -> core::result::Result<proc_macro2::TokenStream, alloc::boxed::Box<(dyn core::error::Error + 'static)>>
 impl moverox_codegen::ModuleGen for move_syn::Module
+pub fn move_syn::Module::to_parts(&self, thecrate: &proc_macro2::TokenStream, package: core::option::Option<&unsynn::literal::LiteralString>, address_map: &std::collections::hash::map::HashMap<proc_macro2::Ident, proc_macro2::TokenStream>) -> core::result::Result<moverox_codegen::ModuleParts, alloc::boxed::Box<(dyn core::error::Error + 'static)>>
 pub fn move_syn::Module::to_rust(&self, thecrate: &proc_macro2::TokenStream, package: core::option::Option<&unsynn::literal::LiteralString>, address_map: &std::collections::hash::map::HashMap<proc_macro2::Ident, proc_macro2::TokenStream>) -> core::result::Result<proc_macro2::TokenStream, alloc::boxed::Box<(dyn core::error::Error + 'static)>>


### PR DESCRIPTION
## What

Adds `ModuleGen::to_parts`, returning a module's oxidized datatypes as
`ModuleParts { ident, docs, body }` — the pieces of a Rust module without the
enclosing `pub mod <ident> { … }` wrapper.

`to_rust` now wraps `to_parts` (it just emits the wrapper around the parts), so
its output is unchanged.

## Why

A caller that already builds its own `mod` for a Move module — e.g. one that
holds both the oxidized datatypes **and** other bindings for the same module
(PTB call bindings, extension impls) — currently can't use `to_rust`, because it
emits a standalone `pub mod`. `to_parts` hands back just the body so the caller
can weave it into a module of its own construction.

This unblocks the realmarkets/dex `pkgs` crate, which is consolidating all
Move-package Rust codegen (oxidized datatypes + PTB bindings) behind a single
`move-syn` parse per package and needs both to land in one shared `pub mod`.

## Compatibility

- `to_rust` output is byte-identical — the codegen snapshots are unchanged.
- The public-API snapshot is updated to include the new `to_parts` method and
  the `ModuleParts` type.