### PR TITLE
fix(move-syn): parse name-access-chain attribute values

### DIFF
--- a/crates/move-syn/src/lib.rs
+++ b/crates/move-syn/src/lib.rs
@@ -179,7 +179,7 @@ unsynn! {
             leading_name_access: Either<SyntaxIdent, Ident>,
             // NOTE: ignoring <OptionalTypeArgs> for now
             // https://github.com/MystenLabs/sui/blob/129788902da4afc54a10af4ae45971a57ef080be/external-crates/move/crates/move-compiler/src/parser/syntax.rs#L3168
-            path: DelimitedVec<PathSep, Ident, TrailingDelimiter::Forbidden>,
+            path: Vec<Cons<PathSep, Ident>>,
         },
     }
 

--- a/crates/move-syn/src/tests/mod.rs
+++ b/crates/move-syn/src/tests/mod.rs
@@ -151,6 +151,19 @@ fn tuple_struct_with_generic_field_type_and_ability() {
 }
 
 #[test]
+fn attribute_with_name_access_chain_value() {
+    // `AttributeValue = <Value> | <NameAccessChain>`: a path like `widget::Widget` is a
+    // valid attribute assignment value, at any nesting depth.
+    for code in [
+        "#[ext(lineage = widget::Widget)]\nfun my_function() {}",
+        "#[ext(versioned(min = f, lineage = a::b::C))]\nfun my_function() {}",
+    ] {
+        let ast: Item = code.to_token_iter().parse_all().unwrap();
+        assert_eq!(ast.tokens_to_string(), code.tokens_to_string());
+    }
+}
+
+#[test]
 fn function_with_compound_attribute() {
     let code = indoc::indoc! {"
     #[allow(unused_function), ext(dev_inspect)]


### PR DESCRIPTION
`AttributeValue`'s `NameAccessChain` had its `DelimitedVec` element and delimiter type parameters swapped — elements were `::` tokens, delimited by idents — so an attribute assignment like `#[ext(lineage = widget::Widget)]` failed to parse the entire file, even though Move's own attribute grammar admits a `NameAccessChain` value. Spell the repetition directly as `Vec<Cons<PathSep, Ident>>`.